### PR TITLE
Add support for stable and beta Chrome releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Rebundle.
 2. Top and tail each feature with the steps "When I start the timer" and "Then I stop the timer"
 3. Create a "config/performance_test.yml" file, referencing your feature(s)
 4. Run the performance tests for Firefox or Chrome
-  * Firefox: `bundle exec rake run_performance_tests[firefox]` (rake arg optional for Firefox)
-  * Chrome : `bundle exec rake run_performance_tests[chrome]`
+  * Firefox: `bundle exec rake run_performance_tests_firefox`.
+  * Chrome : `bundle exec rake run_performance_tests_chrome_release`.
+  * Chrome Beta: `bundle exec rake run_performance_tests_chrome_beta`.
 
 ### Architecture
 

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -11,3 +11,10 @@ performance_chrome: >
   --format pretty 
   --format html 
   --out target/reports/integration-test.html
+
+performance_test: >
+  --require features/step_definitions 
+  --require lib/performance_test/performance_test_steps.rb 
+  --format pretty 
+  --format html 
+  --out target/reports/integration-test.html

--- a/lib/tasks/performance_test.rake
+++ b/lib/tasks/performance_test.rake
@@ -1,29 +1,21 @@
 require 'performance_test/performance_test_runner'
 
 desc "Run all performance tests"
-task :run_performance_tests, [:browser] do |t,args|
-  browser = args[:browser] || 'firefox'
-  release = 'stable'
-  PerformanceTestRunner.new(browser, release).run
+task :run_performance_tests, [:browser,:release] do |t,args|
+  PerformanceTestRunner.new(args[:browser], args[:release]).run
 end
 
 desc "Run all performance tests against Chrome release"
 task :run_performance_tests_chrome_release do
-  browser = 'chrome'
-  release = 'release'
-  PerformanceTestRunner.new(browser, release).run
+  PerformanceTestRunner.new('chrome', 'release').run
 end
 
 desc "Run all performance tests against Chrome beta"
 task :run_performance_tests_chrome_beta do
-  browser = 'chrome'
-  release = 'beta'
-  PerformanceTestRunner.new(browser, release).run
+  PerformanceTestRunner.new('chrome', 'beta').run
 end
 
 desc "Run all performance tests against Firefox"
-task :run_performance_tests_chrome_firefox do
-  browser = 'firefox'
-  release = 'stable'
-  PerformanceTestRunner.new(browser, release).run
+task :run_performance_tests_firefox do
+  PerformanceTestRunner.new('firefox', 'stable').run
 end

--- a/lib/tasks/performance_test.rake
+++ b/lib/tasks/performance_test.rake
@@ -3,5 +3,27 @@ require 'performance_test/performance_test_runner'
 desc "Run all performance tests"
 task :run_performance_tests, [:browser] do |t,args|
   browser = args[:browser] || 'firefox'
-  PerformanceTestRunner.new(browser).run
+  release = 'stable'
+  PerformanceTestRunner.new(browser, release).run
+end
+
+desc "Run all performance tests against Chrome release"
+task :run_performance_tests_chrome_release do
+  browser = 'chrome'
+  release = 'release'
+  PerformanceTestRunner.new(browser, release).run
+end
+
+desc "Run all performance tests against Chrome beta"
+task :run_performance_tests_chrome_beta do
+  browser = 'chrome'
+  release = 'beta'
+  PerformanceTestRunner.new(browser, release).run
+end
+
+desc "Run all performance tests against Firefox"
+task :run_performance_tests_chrome_firefox do
+  browser = 'firefox'
+  release = 'stable'
+  PerformanceTestRunner.new(browser, release).run
 end

--- a/spec/integration/integration_test_spec.rb
+++ b/spec/integration/integration_test_spec.rb
@@ -3,59 +3,60 @@ require 'spec_helper'
 RSpec.shared_examples "records the correct results" do
   it "should record the correct results" do
     # should fail the first test because the threshold is exceeded
-    expect(@runner.results[0][:threshold_pass]).to eq false
+    expect(runner.results[0][:threshold_pass]).to eq false
 
     # should pass the second test
-    expect(@runner.results[1][:threshold_pass]).to eq true
-    expect(@runner.results[1][:feature_pass]).to eq true
+    expect(runner.results[1][:threshold_pass]).to eq true
+    expect(runner.results[1][:feature_pass]).to eq true
 
     # should fail the third test because the cucumber feature doesn't exist
-    expect(@runner.results[2][:feature_pass]).to eq false
+    expect(runner.results[2][:feature_pass]).to eq false
   end
 end
 
 describe PerformanceTest do
 
-  before(:each) do
+  let(:fixture_config_path) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'integration_test.yml') }
 
+  before do
     repository = double('repository')
     repository.should_receive(:save).once
     ResultsRepository.should_receive(:new).and_return(repository)
-
-    @fixtureConfigPath = File.join(File.dirname(__FILE__), '..', 'fixtures', 'integration_test.yml')
   end
 
   describe 'when running against firefox' do
+    let(:runner) { PerformanceTestRunner.new 'firefox', 'stable' }
     before do
-      @runner = PerformanceTestRunner.new 'firefox', @fixtureConfigPath
       begin
-        @runner.run
+        runner.config_path = fixture_config_path
+        runner.run
       rescue
       end
     end
 
     it 'uses the correct threshold' do
-      expect(@runner.results[0][:test]['threshold']).to eq 1
-      expect(@runner.results[1][:test]['threshold']).to eq 6000
-      expect(@runner.results[2][:test]['threshold']).to eq 400000
+      expect(runner.results[0][:test]['threshold']).to eq 1
+      expect(runner.results[1][:test]['threshold']).to eq 6000
+      expect(runner.results[2][:test]['threshold']).to eq 400000
     end
 
     include_examples "records the correct results"
   end
 
   describe 'when running against chrome' do
+    let(:runner) { PerformanceTestRunner.new 'chrome', 'stable' }
     before do
-      @runner = PerformanceTestRunner.new 'chrome', @fixtureConfigPath
       begin
-        @runner.run
+        runner.config_path = fixture_config_path
+        runner.run
       rescue
       end
     end
 
     it 'uses the correct threshold' do
-      expect(@runner.results[0][:test]['threshold']).to eq 1
-      expect(@runner.results[1][:test]['threshold']).to eq 5000
-      expect(@runner.results[2][:test]['threshold']).to eq 300000
+      expect(runner.results[0][:test]['threshold']).to eq 1
+      expect(runner.results[1][:test]['threshold']).to eq 5000
+      expect(runner.results[2][:test]['threshold']).to eq 300000
     end
 
     include_examples "records the correct results"

--- a/spec/unit/performance_test_runner_spec.rb
+++ b/spec/unit/performance_test_runner_spec.rb
@@ -9,58 +9,162 @@ end
 
 describe PerformanceTestRunner do
 
-  before do
-    fixtureConfigPath = File.join(File.dirname(__FILE__), '..', 'fixtures', 'example_config.yml')
-    @runner = PerformanceTestRunner.new 'chrome', fixtureConfigPath
+  let(:fixture_config_path) do
+    File.join(File.dirname(__FILE__), '..', 'fixtures', 'example_config.yml')
   end
 
-  describe '#load_config' do
+  let(:firefox_runner) { PerformanceTestRunner.new 'firefox', 'stable' }
+  let(:chrome_release_runner) { PerformanceTestRunner.new 'chrome', 'stable' }
+  let(:chrome_beta_runner) { PerformanceTestRunner.new 'chrome', 'beta' }
 
-    describe 'when the file exists' do
-      it 'loads and parses the file' do
-        @runner.config['tests'].length.should == 2
+
+  describe 'configuration file' do
+    it 'sets a sensible default' do
+      expect(chrome_release_runner.instance_variable_get(:@config_path)).not_to be_nil
+    end
+
+    it 'exposes a writer for custom path' do
+      custom_path = '/path/to/config.yml'
+      expect {
+        chrome_release_runner.config_path = custom_path
+      }.to change {
+        chrome_release_runner.instance_variable_get(:@config_path)
+      }.to(custom_path)
+    end
+  end
+
+  describe '#run_setup' do
+    describe 'validating the config_file' do
+      before { chrome_release_runner.config_path = 'nonexistant' }
+
+      it 'raises an error when file not found' do
+        expect { chrome_release_runner.send(:run_setup) }.to raise_error(RuntimeError)
       end
     end
 
-    describe 'when the config file doesnt exist' do
-      it 'an exception is raised' do
-          expect { PerformanceTestRunner.new 'chrome', '/some/bogus/path' }.to raise_error(RuntimeError)
+    describe 'loading the configuration from config_file' do
+      before do
+        chrome_release_runner.config_path = fixture_config_path
+        chrome_release_runner.send(:run_setup)
+      end
+
+      it 'sets and exposes configuration' do
+        expect(chrome_release_runner.config.keys).to eq ['parallel-tasks','db_options','tests','results_table']
       end
     end
-  end
 
-  describe '#prepare_tests' do
-    it 'returns 4 instances of test "Example test"' do
-      tests = @runner.tests.select {|test| test[:test]["name"] == "Example test"}
-      tests.length.should == 4
+    describe 'setting the table for persistence' do
+      describe 'when using firefox' do
+        before do
+          firefox_runner.config_path = fixture_config_path
+          firefox_runner.send(:run_setup)
+        end
+
+        it 'persists to performance_test_results' do
+          expect(firefox_runner.config['results_table']).to eq 'performance_test_results'
+        end
+      end
+
+      describe 'when using chrome release' do
+        before do
+          chrome_release_runner.config_path = fixture_config_path
+          chrome_release_runner.send(:run_setup)
+        end
+
+        it 'persists to performance_test_results_chrome' do
+          expect(chrome_release_runner.config['results_table']).to eq 'performance_test_results_chrome'
+        end
+      end
+
+      describe 'when using chrome beta' do
+        before do
+          chrome_beta_runner.config_path = fixture_config_path
+          chrome_beta_runner.send(:run_setup)
+        end
+
+        it 'persists to performance_test_results_chrome_beta' do
+          expect(chrome_beta_runner.config['results_table']).to eq 'performance_test_results_chrome_beta'
+        end
+      end
     end
 
-    it 'returns 2 instances of test "Example test 2"' do
-      tests = @runner.tests.select {|test| test[:test]["name"] == "Example test 2"}
-      tests.length.should == 2
-    end
+    describe 'preparing the tests' do
+      describe 'when using firefox' do
+        before do
+          firefox_runner.config_path = fixture_config_path
+          firefox_runner.send(:run_setup)
+        end
 
-    it 'returns test_instances with the correct keys' do
-      @runner.tests[0].should have_key :name
-      @runner.tests[0].should have_key :cmd
-      @runner.tests[0].should have_key :test
-    end
+        it 'uses the correct test profile' do
+          firefox_runner.tests[0][:cmd].should eq 'bundle exec cucumber -p performance_test features/christo/example_performance.feature 2>&1'
+        end
+      end
 
-    it 'uses the correct test profile' do
-      @runner.tests[0][:cmd].should eq 'bundle exec cucumber -p performance_chrome features/christo/example_performance.feature 2>&1'
+      describe 'when using chrome release' do
+        before do
+          chrome_release_runner.config_path = fixture_config_path
+          chrome_release_runner.send(:run_setup)
+        end
+
+        it 'uses the correct test profile' do
+          chrome_release_runner.tests[0][:cmd].should eq 'bundle exec cucumber -p performance_chrome features/christo/example_performance.feature 2>&1'
+        end
+      end
+
+      describe 'when using chrome beta' do
+        before do
+          chrome_beta_runner.config_path = fixture_config_path
+          chrome_beta_runner.send(:run_setup)
+        end
+
+        it 'uses the correct test profile' do
+          chrome_beta_runner.tests[0][:cmd].should eq 'bundle exec cucumber -p performance_chrome features/christo/example_performance.feature 2>&1'
+        end
+      end
+
+      describe 'for all browsers' do
+        before do
+          chrome_release_runner.config_path = fixture_config_path
+          chrome_release_runner.send(:run_setup)
+        end
+
+        it 'loads and parses from the file file' do
+          chrome_release_runner.config['tests'].length.should == 2
+        end
+
+        it 'returns 4 instances of test "Example test"' do
+          tests = chrome_release_runner.tests.select {|test| test[:test]["name"] == "Example test"}
+          tests.length.should == 4
+        end
+
+        it 'returns 2 instances of test "Example test 2"' do
+          tests = chrome_release_runner.tests.select {|test| test[:test]["name"] == "Example test 2"}
+          tests.length.should == 2
+        end
+
+        it 'returns test_instances with the correct keys' do
+          chrome_release_runner.tests[0].should have_key :name
+          chrome_release_runner.tests[0].should have_key :cmd
+          chrome_release_runner.tests[0].should have_key :test
+        end
+      end
     end
   end
 
   describe '#run_tests' do
+    before do
+      chrome_release_runner.config_path = fixture_config_path
+      chrome_release_runner.send(:run_setup)
+    end
+
     it 'calls Parallel.new with the test_instances' do
-
       parallel = double('parallel', run: nil)
-      Parallel.should_receive(:new).with(@runner.tests, @runner.config['parallel-tasks'].to_i).and_return(parallel)
+      Parallel.should_receive(:new).with(
+        chrome_release_runner.tests,
+        chrome_release_runner.config['parallel-tasks'].to_i
+      ).and_return(parallel)
 
-      with_silent_stdout do
-        @runner.send :run_tests
-      end
+      with_silent_stdout { chrome_release_runner.send(:run_tests) }
     end
   end
-
 end


### PR DESCRIPTION
Kicked off with: @gary-rafferty

#### Description

We are now running performance tests against Chrome's stable and beta releases.
This PR differentiates between the two at initialization, and handles accordingly. 
Also adds some convenience rake tasks rather than relying on rake arguments.

_Deliverables_
- [ ] Gem can handle Chrome beta and Chrome release