### PR TITLE
remove versioned dependency on rake 10

### DIFF
--- a/performance_test.gemspec
+++ b/performance_test.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'rake', '~> 10.5.0'
+  gem.add_runtime_dependency 'rake'
   gem.add_runtime_dependency 'pg'
 
   gem.add_runtime_dependency 'diff-lcs', '~> 1.2.5'


### PR DESCRIPTION
Kicked off with @gary-rafferty

No need for the hard dependency on v10 of Rake