### PR TITLE
Fix hanging performance tests

### DIFF
--- a/lib/performance_test/performance_test_runner.rb
+++ b/lib/performance_test/performance_test_runner.rb
@@ -78,7 +78,7 @@ class PerformanceTestRunner
       (1..number_of_test_runs).map do |i|
         {
           name: "#{test['name']} - Run #{i}",
-          cmd: "bundle exec cucumber -p performance #{test['feature']} 2>&1",
+          cmd: "bundle exec cucumber -p performance #{test['feature']} 2>&1 | grep TIME_TAKEN",
           test: test
         }
       end

--- a/lib/performance_test/version.rb
+++ b/lib/performance_test/version.rb
@@ -1,3 +1,3 @@
 module PerformanceTest
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
Recent changes to Atlas are throwing a huge amount of deprecations when running cucumber tests. Those are filling a buffer that is used in the rake task used by Christo Performance.